### PR TITLE
remove ingress / tls from kustomize manifest

### DIFF
--- a/kustomize/herringbone/kustomization.yaml
+++ b/kustomize/herringbone/kustomization.yaml
@@ -6,8 +6,6 @@ namespace: herringbone
 resources:
   - deployment.yaml
   - service.yaml
-  - ingress.yaml
-  - app-herringbone-dev-tls.yaml
 
 images:
   - name: quay.io/herringbone/herringbone-app


### PR DESCRIPTION
Remove ingress and tls from kustomize manifests since dev environment moved from GCP to on-prem and they no longer work.