### PR TITLE
Potential fix for code scanning alert no. 56: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,5 +1,8 @@
 name: PR Validation
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/herringbonedev/Herringbone/security/code-scanning/56](https://github.com/herringbonedev/Herringbone/security/code-scanning/56)

In general, fix this by adding an explicit `permissions` block that grants only the scopes required by the workflow. For a typical validation workflow that only checks out code and runs tests, `contents: read` is usually sufficient; if no other API interactions occur, other scopes can be omitted.

The single best fix here is to add a root-level `permissions` block (near the top of `.github/workflows/pr-validation.yml`, alongside `name` and `on`). This will apply to all jobs (`detect-changes`, `element-tests`, and `finalize`) since none of them currently define their own `permissions`. Based on the provided snippet, the workflow only needs to read repository contents (for `actions/checkout` and `git diff`), so `contents: read` is adequate. No behavior of the existing steps changes; we simply constrain the `GITHUB_TOKEN` if it is used, and future steps will inherit this least-privilege configuration unless they override it.

Concretely:
- Edit `.github/workflows/pr-validation.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  after the `name: PR Validation` line (line 1–2 region) and before the `on:` block.
- No new imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
