### PR TITLE
Potential fix for code scanning alert no. 24: Information exposure through an exception

### DIFF
--- a/logingestion/receiver/app/web.py
+++ b/logingestion/receiver/app/web.py
@@ -66,7 +66,7 @@ def receiver():
             return ("Data received", 200)
         except Exception as e:
             print(f"[✗] Mongo insert operation failed: {e}")
-            return (f"Insert failed: {e}", 500)
+            return ("Insert failed; check server logs for details.", 500)
     else:
         result = forward_data(forward_route, data, addr)
         if result:


### PR DESCRIPTION
Potential fix for [https://github.com/herringbonedev/Herringbone/security/code-scanning/24](https://github.com/herringbonedev/Herringbone/security/code-scanning/24)

In general, the fix is to avoid returning the raw exception message to the client. Instead, log the detailed error (including the exception) on the server side and return a generic message such as "Internal server error" or "Database error" with the appropriate HTTP status code.

Concretely, in `logingestion/receiver/app/web.py`, inside the `receiver()` function’s `if forward_route is None:` block, the `except Exception as e:` currently logs the error using `print` and then returns a response that includes the stringified exception. We should keep (or slightly improve) the server-side logging but change the HTTP response body to a generic message that does not interpolate `e`. To minimize changes, we can keep using `print` for logging; introducing structured logging would be nice but is not required to fix the vulnerability.

So, update the `return (f"Insert failed: {e}", 500)` line (around line 69) to instead return something like `("Insert failed; check server logs for details.", 500)`, leaving the `print(f"[✗] Mongo insert operation failed: {e}")` line intact for server-side diagnostics. No new imports or helper methods are strictly necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
