### PR TITLE
Potential fix for code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/logingestion/receiver/app/remote.py
+++ b/logingestion/receiver/app/remote.py
@@ -67,7 +67,7 @@ def receiver_v2():
 
     except Exception as e:
         print(f"[✗] Mongo insert operation failed: {e}")
-        return (f"Insert failed: {e}", 500)
+        return ("Insert failed; check server logs for details.", 500)
 
 
 def start_remote_receiver():


### PR DESCRIPTION
Potential fix for [https://github.com/herringbonedev/Herringbone/security/code-scanning/10](https://github.com/herringbonedev/Herringbone/security/code-scanning/10)

To fix the problem, the error message returned to the client must be decoupled from the internal exception details. The server should still log the full exception (for debugging and auditing) but respond with a generic, non-sensitive message to the HTTP client.

The best targeted fix here is to keep the existing `print` logging of `e` in the `except` block for the insert operation, but replace the HTTP response body so it no longer contains `e`. Concretely, in `logingestion/receiver/app/remote.py`, lines 68–70 are:

```py
    except Exception as e:
        print(f"[✗] Mongo insert operation failed: {e}")
        return (f"Insert failed: {e}", 500)
```

We should change only the returned string to something generic like `"Insert failed; check server logs for details."`, keeping the status code 500 unchanged to preserve existing behavior as much as possible.

No new imports or helper methods are needed; we can reuse the existing `print` logging. This ensures no exception detail is exposed to the user, while preserving current logic and response codes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
